### PR TITLE
transformation_type.py and transformations_api.py changed

### DIFF
--- a/cognite/transformations_cli/commands/deploy/transformation_types.py
+++ b/cognite/transformations_cli/commands/deploy/transformation_types.py
@@ -89,6 +89,7 @@ class DMIDestinationConfig:
     instance_space_external_id: str
     type: DestinationType = DestinationType.data_model_instances
 
+        
 
 @dataclass
 class ViewInfo:

--- a/cognite/transformations_cli/commands/deploy/transformation_types.py
+++ b/cognite/transformations_cli/commands/deploy/transformation_types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional, Union , Literal
 
 
 class DestinationType(str,Enum):

--- a/cognite/transformations_cli/commands/deploy/transformation_types.py
+++ b/cognite/transformations_cli/commands/deploy/transformation_types.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional, Union
 
 
-class DestinationType(Enum):
+class DestinationType(str,Enum):
     assets = "assets"
     timeseries = "timeseries"
     asset_hierarchy = "asset_hierarchy"
@@ -96,6 +96,10 @@ class ViewInfo:
     external_id: str
     version: str
 
+    def __init__(self, space: str, external_id: str, version: Union[int, str]):
+        self.space = space
+        self.external_id = external_id
+        self.version = str(version)
 
 @dataclass
 class EdgeType:
@@ -111,7 +115,7 @@ class InstanceNodesDestinationConfig:
 
     view: Optional[ViewInfo]
     instance_space: Optional[str]
-    type: DestinationType = DestinationType.nodes
+    type: Literal[DestinationType.nodes] = DestinationType.nodes
 
 
 @dataclass
@@ -123,7 +127,7 @@ class InstanceEdgesDestinationConfig:
     view: Optional[ViewInfo]
     instance_space: Optional[str]
     edge_type: Optional[EdgeType]
-    type: DestinationType = DestinationType.edges
+    type: Literal[DestinationType.edges] = DestinationType.edges
 
 
 @dataclass

--- a/cognite/transformations_cli/commands/deploy/transformations_api.py
+++ b/cognite/transformations_cli/commands/deploy/transformations_api.py
@@ -99,23 +99,20 @@ def to_destination(destination: DestinationConfigType) -> TransformationDestinat
         return DataModelInstances(
             destination.model_external_id, destination.space_external_id, destination.instance_space_external_id
         )
-    elif isinstance(destination, InstanceNodesDestinationConfig) or isinstance(
-        destination, InstanceEdgesDestinationConfig
-    ):
-        if destination.type == InstanceNodesDestinationConfig.type:
-            view = None
-            if destination.view:
-                view = ViewInfo(destination.view.space, destination.view.external_id, destination.view.version)
-            return InstanceNodes(view, destination.instance_space)
-        elif destination.type == InstanceEdgesDestinationConfig.type:
-            view = None
-            if destination.view:
-                view = ViewInfo(destination.view.space, destination.view.external_id, destination.view.version)
-            edge_type = None
-            # This is a hack, we should have better fix since destination is still InstanceNodesDestinationConfig here...
-            if isinstance(destination, InstanceEdgesDestinationConfig) and destination.edge_type:
-                edge_type = EdgeType(destination.edge_type.space, destination.edge_type.external_id)
-            return InstanceEdges(view, destination.instance_space, edge_type)
+    elif isinstance(destination, InstanceNodesDestinationConfig):
+        view = None
+        if destination.view:
+            view = ViewInfo(destination.view.space, destination.view.external_id, destination.view.version)
+        return InstanceNodes(view, destination.instance_space)
+    
+    elif isinstance(destination, InstanceEdgesDestinationConfig):
+        view = None
+        if destination.view:
+            view = ViewInfo(destination.view.space, destination.view.external_id, destination.view.version)
+        edge_type = None
+        if destination.edge_type:
+        edge_type = EdgeType(destination.edge_type.space, destination.edge_type.external_id)
+        return InstanceEdges(view, destination.instance_space, edge_type)
     else:
         return TransformationDestination(destination.value)
 

--- a/cognite/transformations_cli/commands/deploy/transformations_api.py
+++ b/cognite/transformations_cli/commands/deploy/transformations_api.py
@@ -111,7 +111,7 @@ def to_destination(destination: DestinationConfigType) -> TransformationDestinat
             view = ViewInfo(destination.view.space, destination.view.external_id, destination.view.version)
         edge_type = None
         if destination.edge_type:
-        edge_type = EdgeType(destination.edge_type.space, destination.edge_type.external_id)
+            edge_type = EdgeType(destination.edge_type.space, destination.edge_type.external_id)
         return InstanceEdges(view, destination.instance_space, edge_type)
     else:
         return TransformationDestination(destination.value)


### PR DESCRIPTION
transformation_type.py: 
class DestinationType(Enum) - > class DestinationType(str,Enum)

Added def __init__(self, space: str, external_id: str, version: Union[int, str]): function to class ViewInfo

type: DestinationType = DestinationType.edges -> type: Literal[DestinationType.nodes] = DestinationType.nodes

type: DestinationType = DestinationType.edges -> type: Literal[DestinationType.edges] = DestinationType.edges

transformations_api.py:
I haven't add new conditions to the isinstance(destination, InstanceNodesDestinationConfig) and isinstance(destination, InstanceEdgesDestinationConfig), this is the previous version 