### PR TITLE
Data model centric destination

### DIFF
--- a/cognite/transformations_cli/commands/deploy/transformation_config.py
+++ b/cognite/transformations_cli/commands/deploy/transformation_config.py
@@ -41,6 +41,11 @@ def _validate_destination_type(external_id: str, destination_type: DestinationCo
                 f"Error on transformation manifest with external ID {external_id}: Edges destination requires view space,  \
                             view external_id, view version, instance_space and edge_type space, edge_type external_id to be set."
             )
+        if flat_destination_type == DestinationType.instances:
+            raise Exception(
+                f"Error on transformation manifest with external ID {external_id}: Instance destination requires data model space,  \
+                            data model external_id, data model version, destinationType, destinationRelationshipFromType (optional) and nstance_space  to be set."
+            )
         if flat_destination_type == DestinationType.sequence_rows:
             raise Exception(
                 f"Error on transformation manifest with external ID {external_id}: Sequence rows destination requires external_id to be set."

--- a/cognite/transformations_cli/commands/deploy/transformation_types.py
+++ b/cognite/transformations_cli/commands/deploy/transformation_types.py
@@ -20,6 +20,7 @@ class DestinationType(str, Enum):
     data_model_instances = "data_model_instances"
     nodes = "nodes"
     edges = "edges"
+    instances = "instances"
 
 
 class ActionType(Enum):
@@ -105,12 +106,43 @@ class ViewInfo:
         self.external_id = external_id
         self.version = str(version)
 
-
 @dataclass
 class EdgeType:
     space: str
     external_id: str
 
+@dataclass
+class DataModelInfo:
+    space: str
+    external_id: str
+    version: Union[int, str]
+    destination_type: str
+    destination_relationship_from_type: Optional[str] = None
+
+    """
+    CAST DataModel version int to string
+    """
+
+    def __init__(self, space: str, external_id: str, version: Union[int, str], destination_type: str, destination_relationship_from_type: Optional[str] = None):
+        self.space = space
+        self.external_id = external_id
+        self.version = str(version)
+        self.destination_type = destination_type
+        self.destination_relationship_from_type = destination_relationship_from_type
+
+    def __hash__(self) -> int:
+        if self.destination_relationship_from_type is not None:
+            return hash(
+                (
+                    self.space,
+                    self.external_id,
+                    self.version,
+                    self.destination_type,
+                    self.destination_relationship_from_type,
+                )
+            )
+        else:
+            return hash((self.space, self.external_id, self.version, self.destination_type))
 
 @dataclass
 class InstanceNodesDestinationConfig:
@@ -121,6 +153,7 @@ class InstanceNodesDestinationConfig:
     view: Optional[ViewInfo]
     instance_space: Optional[str]
     type: Literal[DestinationType.nodes] = DestinationType.nodes
+
 
 
 @dataclass
@@ -136,6 +169,15 @@ class InstanceEdgesDestinationConfig:
         DestinationType.edges
     ] = DestinationType.edges  # DestinationType updated with  Literal[DestinationType.edges]
 
+@dataclass
+class InstanceDataModelDestinationConfig:
+    """
+    Valid type values are: instances
+    """
+
+    data_model: Optional[DataModelInfo]
+    instance_space: Optional[str]
+    type: Literal[DestinationType.instances] = DestinationType.instances
 
 @dataclass
 class SequenceRowsDestinationConfig:
@@ -156,6 +198,7 @@ DestinationConfigType = Union[
     InstanceNodesDestinationConfig,
     InstanceEdgesDestinationConfig,
     RawDestinationAlternativeConfig,
+    InstanceDataModelDestinationConfig,
 ]
 
 

--- a/cognite/transformations_cli/commands/deploy/transformations_api.py
+++ b/cognite/transformations_cli/commands/deploy/transformations_api.py
@@ -16,8 +16,10 @@ from cognite.client.data_classes.transformations.common import (
     EdgeType,
     InstanceEdges,
     InstanceNodes,
+    InstanceDataModel,
     SequenceRows,
     ViewInfo,
+    DataModelInfo,
 )
 from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError, CogniteNotFoundError
 
@@ -29,6 +31,7 @@ from cognite.transformations_cli.commands.deploy.transformation_types import (
     DMIDestinationConfig,
     InstanceEdgesDestinationConfig,
     InstanceNodesDestinationConfig,
+    InstanceDataModelDestinationConfig,
     QueryConfig,
     RawDestinationAlternativeConfig,
     RawDestinationConfig,
@@ -129,6 +132,18 @@ def to_destination(destination: DestinationConfigType) -> TransformationDestinat
         if destination.edge_type:
             edge_type = EdgeType(destination.edge_type.space, destination.edge_type.external_id)
         return InstanceEdges(view, destination.instance_space, edge_type)
+
+    elif isinstance(destination, InstanceDataModelDestinationConfig):
+        data_model = None
+        if destination.data_model:
+            data_model = DataModelInfo(
+                destination.data_model.space,
+                destination.data_model.external_id,
+                destination.data_model.version,
+                destination.data_model.destination_type,
+                destination.data_model.destination_relationship_from_type,
+            )
+        return InstanceDataModel(data_model, destination.instance_space)
 
     else:
         return TransformationDestination(destination.value)


### PR DESCRIPTION
- cognite/transformations_cli/commands/deploy/transformation_config.py

_validate_destination_type  -> DestinationType.instances

- cognite/transformations_cli/commands/deploy/transformation_types.py

deployed class InstanceDataModelDestinationConfig

- cognite/transformations_cli/commands/deploy/transformations_api.py

to_destination -> InstanceDataModel

- tests/test_deploy.py

Defined test_deploy_instance_data_model_with_space_transformation ()

