### PR TITLE
Use pre-built container in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     default: "false"
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: docker://cognite/transformations-cli:v2.3.9
   env:
     TRANSFORMATIONS_API_KEY: ${{ inputs.api-key }}
     TRANSFORMATIONS_TOKEN_URL: ${{ inputs.token-url }}
@@ -50,4 +50,3 @@ runs:
     TRANSFORMATIONS_CLUSTER: "${{ inputs.cluster }}"
     TRANSFORMATIONS_LEGACY_MODE: ${{ inputs.legacy-mode }}
   args: ["deploy", "${{ inputs.path }}" , "--debug"]
-  


### PR DESCRIPTION
It takes 40 seconds to build the Dockerfile on every github deploy. We can use the pre-built container (we already did this for the function-action)