### PR TITLE
added poetry version binding for azure docker file

### DIFF
--- a/Dockerfile-azure-pipelines
+++ b/Dockerfile-azure-pipelines
@@ -6,7 +6,7 @@ WORKDIR /
 ENV PYTHONUNBUFFERED=1
 
 # Poetry setup
-RUN pip3 install poetry
+RUN pip3 install poetry==1.8.3
 RUN poetry config virtualenvs.create false
 
 COPY poetry.lock .


### PR DESCRIPTION
bound poetry version in azure pipeline Dockerfile to specific version

the Dockerfile is using RUN pip install poetry which installs latest poetry
poetry made a breaking change release to [2.0.0](https://github.com/python-poetry/poetry/releases/tag/2.0.0) at 2025-01-05
which broke using it as gh-action
simple solution is fixing the version to one from before v1.8.*
which should be the best-practice anyway :)
pls approve merge and make a release with tag v2.3.12